### PR TITLE
2021 - Day 16

### DIFF
--- a/AdventOfCode2021.Tests/Days/Day16Tests.cs
+++ b/AdventOfCode2021.Tests/Days/Day16Tests.cs
@@ -1,0 +1,101 @@
+namespace AdventOfCode2021.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using AdventOfCode2021.Days.Day16;
+
+    [TestClass]
+    public class Day16Tests
+    {
+        [TestMethod]
+        public void Parse_LiteralString_ReturnsLiteral()
+        {
+            var input = Part1.ToBinary("D2FE28");
+
+            var result = Packet.Parse(input);
+
+            Assert.AreEqual(new Literal(6, 7 * 16 * 16 + 14 * 16 + 5), result);
+        }
+
+        [TestMethod]
+        public void Parse_OperatorString_ReturnsOperator()
+        {
+            var input = Part1.ToBinary("38006F45291200");
+
+            var result = Packet.Parse(input);
+
+            var expected = new Operator()
+            {
+                Version = 1,
+                Type = (PacketType)6,
+                SubPackets = new IPacket[]
+                {
+                    new Literal(6, 10),
+                    new Literal(2, 20),
+                }
+            };
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void Parse_OtherOperatorString_ReturnsOperator()
+        {
+            var input = Part1.ToBinary("EE00D40C823060");
+
+            var result = Packet.Parse(input);
+
+            var expected = new Operator()
+            {
+                Version = 7,
+                Type = (PacketType)3,
+                SubPackets = new IPacket[]
+                {
+                    new Literal(2, 1),
+                    new Literal(4, 2),
+                    new Literal(1, 3),
+                }
+            };
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        public void SumVersionNumbers_ForFirstExample_Returns16()
+        {
+            var input = "8A004A801A8002F478";
+
+            var result = Part1.SumVersionNumbers(input);
+
+            Assert.AreEqual(16, result);
+        }
+
+        [TestMethod]
+        public void SumVersionNumbers_ForSecondExample_Returns12()
+        {
+            var input = "620080001611562C8802118E34";
+
+            var result = Part1.SumVersionNumbers(input);
+
+            Assert.AreEqual(12, result);
+        }
+
+        [TestMethod]
+        public void SumVersionNumbers_ForThirdExample_Returns23()
+        {
+            var input = "C0015000016115A2E0802F182340";
+
+            var result = Part1.SumVersionNumbers(input);
+
+            Assert.AreEqual(23, result);
+        }
+
+        [TestMethod]
+        public void SumVersionNumbers_ForFourthExample_Returns31()
+        {
+            var input = "A0016C880162017C3686B18A3D4780";
+
+            var result = Part1.SumVersionNumbers(input);
+
+            Assert.AreEqual(31, result);
+        }
+    }
+}

--- a/AdventOfCode2021.Tests/Days/Day16Tests.cs
+++ b/AdventOfCode2021.Tests/Days/Day16Tests.cs
@@ -8,26 +8,26 @@ namespace AdventOfCode2021.Tests
     public class Day16Tests
     {
         [TestMethod]
-        public void Parse_LiteralString_ReturnsLiteral()
+        public void ParseHex_LiteralString_ReturnsLiteral()
         {
-            var input = Part1.ToBinary("D2FE28");
+            var input = "D2FE28";
 
-            var result = Packet.Parse(input);
+            var result = Packet.ParseHex(input);
 
             Assert.AreEqual(new Literal(6, 7 * 16 * 16 + 14 * 16 + 5), result);
         }
 
         [TestMethod]
-        public void Parse_OperatorString_ReturnsOperator()
+        public void ParseHex_OperatorString_ReturnsOperator()
         {
-            var input = Part1.ToBinary("38006F45291200");
+            var input = "38006F45291200";
 
-            var result = Packet.Parse(input);
+            var result = Packet.ParseHex(input);
 
             var expected = new Operator()
             {
                 Version = 1,
-                Type = (PacketType)6,
+                Type = PacketType.LessThan,
                 SubPackets = new IPacket[]
                 {
                     new Literal(6, 10),
@@ -40,14 +40,14 @@ namespace AdventOfCode2021.Tests
         [TestMethod]
         public void Parse_OtherOperatorString_ReturnsOperator()
         {
-            var input = Part1.ToBinary("EE00D40C823060");
+            var input = "EE00D40C823060";
 
-            var result = Packet.Parse(input);
+            var result = Packet.ParseHex(input);
 
             var expected = new Operator()
             {
                 Version = 7,
-                Type = (PacketType)3,
+                Type = PacketType.Maximum,
                 SubPackets = new IPacket[]
                 {
                     new Literal(2, 1),
@@ -96,6 +96,86 @@ namespace AdventOfCode2021.Tests
             var result = Part1.SumVersionNumbers(input);
 
             Assert.AreEqual(31, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForSumExampleString_Returns3()
+        {
+            var input = "C200B40A82";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(3UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForProductExampleString_Returns54()
+        {
+            var input = "04005AC33890";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(54UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForMinimumExampleString_Returns7()
+        {
+            var input = "880086C3E88112";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(7UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForMaximumExampleString_Returns9()
+        {
+            var input = "CE00C43D881120";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(9UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForLessThanExampleString_Returns1()
+        {
+            var input = "D8005AC2A8F0";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(1UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForGreaterThanExampleString_Returns0()
+        {
+            var input = "F600BC2D8F";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(0UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForEqualToExampleString_Returns0()
+        {
+            var input = "9C005AC2F8F0";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(0UL, result);
+        }
+
+        [TestMethod]
+        public void Evaluate_ForComplexExampleString_Returns1()
+        {
+            var input = "9C0141080250320F1802104A08";
+
+            var result = Part2.Evaluate(input);
+
+            Assert.AreEqual(1UL, result);
         }
     }
 }

--- a/AdventOfCode2021/Days/Day16/Data.cs
+++ b/AdventOfCode2021/Days/Day16/Data.cs
@@ -1,0 +1,115 @@
+namespace AdventOfCode2021.Days.Day16
+{
+    public enum PacketType : byte { Literal = 4 }
+
+    public interface IPacket
+    {
+        byte Version { get; }
+
+        PacketType Type { get; }
+    }
+
+    public readonly record struct Literal(byte Version, int Value) : IPacket
+    {
+        public PacketType Type => PacketType.Literal;
+    }
+
+    public readonly record struct Operator(byte Version, PacketType Type, IPacket[] SubPackets) : IPacket
+    {
+        public override string ToString()
+            => $@"Operator {{ Version = { this.Version }, Type = { this.Type }, SubPackets = [{ string.Join(", ", this.SubPackets.Select(_ => _.ToString())) }]}}";
+
+        public bool Equals(Operator other)
+            => other is Operator o && this.Version == o.Version && this.Type == o.Type && this.SubPackets.SequenceEqual(o.SubPackets);
+
+        public override int GetHashCode()
+            => this.SubPackets.OfType<object>()
+                .Prepend(this.Type)
+                .Prepend(this.Version)
+                .Select(_ => _.GetHashCode())
+                .Aggregate(0, HashCode.Combine);
+    }
+
+    public static class Packet
+    {
+        public static IPacket Parse(string input) => ReadPacket(input).Result;
+
+        public static (IPacket Result, int NextIndex) ReadPacket(ReadOnlySpan<char> bits)
+            => (PacketType)ReadByte(bits[3..6]) switch
+            {
+                PacketType.Literal => ReadLiteral(bits),
+                var other => ReadOperator(bits, other),
+            };
+
+        public static (Literal, int) ReadLiteral(ReadOnlySpan<char> bits)
+        {
+            var version = ReadByte(bits[0..3]);
+            var digits = new List<byte>();
+            var hasNextDigit = false;
+            var nextIndex = 6;
+
+            do
+            {
+                hasNextDigit = bits[nextIndex] == '1';
+                digits.Add(ReadByte(bits[(nextIndex + 1)..(nextIndex + 5)]));
+                nextIndex += 5;
+            } while(hasNextDigit);
+
+            var literal = new Literal(version, digits.Aggregate(0, (a, d) => a * 16 + d));
+
+            return (literal, nextIndex);
+        }
+
+        public static (Operator, int) ReadOperator(ReadOnlySpan<char> bits, PacketType type)
+        {
+            var version = ReadByte(bits[0..3]);
+            var packetType = ReadByte(bits[3..6]);
+            var packets = new IPacket[0];
+            var nextIndex = 0;
+
+            if (bits[6] == '1')
+            {
+                var length = ReadNumber(bits[7..18]);
+                packets = new IPacket[length];
+                nextIndex = 18;
+
+                for (var i = 0; i < length; ++i)
+                {
+                    var (p, n) = ReadPacket(bits.Slice(nextIndex));
+                    packets[i] = p;
+                    nextIndex += n;
+                }
+            }
+            else
+            {
+                var length = ReadNumber(bits[7..22]);
+                var ps = new List<IPacket>();
+                nextIndex = 22;
+                var endIndex = 22 + length;
+
+                do
+                {
+                    var (packet, next) = ReadPacket(bits.Slice(nextIndex, endIndex - nextIndex));
+
+                    ps.Add(packet);
+                    nextIndex += next;
+                } while(nextIndex != endIndex);
+
+                packets = ps.ToArray();
+            }
+
+            return (new Operator(version, (PacketType)packetType, packets.ToArray()), nextIndex);
+        }
+
+        public static byte ReadByte(ReadOnlySpan<char> bits) => (byte)ReadNumber(bits);
+
+        public static int ReadNumber(ReadOnlySpan<char> bits)
+        {
+            var result = 0;
+
+            for (var i = 0; i < bits.Length; ++i) result = result * 2 + (bits[i] == '1' ? 1 : 0);
+
+            return result;
+        }
+    }
+}

--- a/AdventOfCode2021/Days/Day16/Data.cs
+++ b/AdventOfCode2021/Days/Day16/Data.cs
@@ -1,6 +1,18 @@
 namespace AdventOfCode2021.Days.Day16
 {
-    public enum PacketType : byte { Literal = 4 }
+    using System.Text;
+
+    public enum PacketType : byte
+    {
+        Sum = 0,
+        Product = 1,
+        Minimum = 2,
+        Maximum = 3,
+        Literal = 4,
+        GreaterThan = 5,
+        LessThan = 6,
+        EqualTo = 7,
+    }
 
     public interface IPacket
     {
@@ -9,7 +21,7 @@ namespace AdventOfCode2021.Days.Day16
         PacketType Type { get; }
     }
 
-    public readonly record struct Literal(byte Version, int Value) : IPacket
+    public readonly record struct Literal(byte Version, ulong Value) : IPacket
     {
         public PacketType Type => PacketType.Literal;
     }
@@ -32,6 +44,17 @@ namespace AdventOfCode2021.Days.Day16
 
     public static class Packet
     {
+        public static string ToBinary(string hexString)
+        {
+            var result = new StringBuilder();
+
+            foreach (var c in hexString) result.Append(Convert.ToString(Convert.ToByte(c.ToString(), 16), 2).PadLeft(4, '0'));
+
+            return result.ToString();
+        }
+
+        public static IPacket ParseHex(string input) => Parse(ToBinary(input));
+
         public static IPacket Parse(string input) => ReadPacket(input).Result;
 
         public static (IPacket Result, int NextIndex) ReadPacket(ReadOnlySpan<char> bits)
@@ -55,7 +78,7 @@ namespace AdventOfCode2021.Days.Day16
                 nextIndex += 5;
             } while(hasNextDigit);
 
-            var literal = new Literal(version, digits.Aggregate(0, (a, d) => a * 16 + d));
+            var literal = new Literal(version, digits.Aggregate(0UL, (a, d) => checked(a * 16 + d)));
 
             return (literal, nextIndex);
         }

--- a/AdventOfCode2021/Days/Day16/Data.cs
+++ b/AdventOfCode2021/Days/Day16/Data.cs
@@ -38,8 +38,8 @@ namespace AdventOfCode2021.Days.Day16
             => this.SubPackets.OfType<object>()
                 .Prepend(this.Type)
                 .Prepend(this.Version)
-                .Select(_ => _.GetHashCode())
-                .Aggregate(0, HashCode.Combine);
+                .Aggregate(new HashCode(), (h, a) => { h.Add(a); return h; })
+                .ToHashCode();
     }
 
     public static class Packet

--- a/AdventOfCode2021/Days/Day16/PacketVisitor.cs
+++ b/AdventOfCode2021/Days/Day16/PacketVisitor.cs
@@ -1,0 +1,17 @@
+namespace AdventOfCode2021.Days.Day16
+{
+    public abstract class PacketVisitor<T>
+    {
+        public T Visit(IPacket packet)
+            => packet switch
+            {
+                Literal l => this.VisitLiteral(l),
+                Operator o => this.VisitOperator(o),
+                _ => throw new InvalidDataException($"Invalid packet { packet }!"),
+            };
+
+        protected abstract T VisitLiteral(Literal l);
+
+        protected abstract T VisitOperator(Operator o);
+    }
+}

--- a/AdventOfCode2021/Days/Day16/Part1.cs
+++ b/AdventOfCode2021/Days/Day16/Part1.cs
@@ -1,21 +1,10 @@
 namespace AdventOfCode2021.Days.Day16
 {
-    using System.Text;
-
     public class Part1 : Solution<int>
     {
         public override int Apply(string[] input) => SumVersionNumbers(input[0]);
 
-        public static string ToBinary(string hexString)
-        {
-            var result = new StringBuilder();
-
-            foreach (var c in hexString) result.Append(Convert.ToString(Convert.ToByte(c.ToString(), 16), 2).PadLeft(4, '0'));
-
-            return result.ToString();
-        }
-
-        public static int SumVersionNumbers(string input) => new VersionNumberSumVisitor().Visit(Packet.Parse(ToBinary(input)));
+        public static int SumVersionNumbers(string input) => new VersionNumberSumVisitor().Visit(Packet.ParseHex(input));
 
         private class VersionNumberSumVisitor : PacketVisitor<int>
         {

--- a/AdventOfCode2021/Days/Day16/Part1.cs
+++ b/AdventOfCode2021/Days/Day16/Part1.cs
@@ -1,0 +1,27 @@
+namespace AdventOfCode2021.Days.Day16
+{
+    using System.Text;
+
+    public class Part1 : Solution<int>
+    {
+        public override int Apply(string[] input) => SumVersionNumbers(input[0]);
+
+        public static string ToBinary(string hexString)
+        {
+            var result = new StringBuilder();
+
+            foreach (var c in hexString) result.Append(Convert.ToString(Convert.ToByte(c.ToString(), 16), 2).PadLeft(4, '0'));
+
+            return result.ToString();
+        }
+
+        public static int SumVersionNumbers(string input) => new VersionNumberSumVisitor().Visit(Packet.Parse(ToBinary(input)));
+
+        private class VersionNumberSumVisitor : PacketVisitor<int>
+        {
+            protected override int VisitLiteral(Literal l) => l.Version;
+
+            protected override int VisitOperator(Operator o) => o.Version + o.SubPackets.Sum(this.Visit);
+        }
+    }
+}

--- a/AdventOfCode2021/Days/Day16/Part2.cs
+++ b/AdventOfCode2021/Days/Day16/Part2.cs
@@ -1,0 +1,28 @@
+namespace AdventOfCode2021.Days.Day16
+{
+    using static PacketType;
+
+    public class Part2 : Solution<ulong>
+    {
+        public override ulong Apply(string[] input) => Evaluate(input[0]);
+
+        public static ulong Evaluate(string input) => new Evaluator().Visit(Packet.ParseHex(input));
+
+        private class Evaluator : PacketVisitor<ulong>
+        {
+            protected override ulong VisitLiteral(Literal l) => l.Value;
+
+            protected override ulong VisitOperator(Operator o) => o.Type switch
+                {
+                    Sum => o.SubPackets.Select(this.Visit).Aggregate(0UL, (a, b) => checked(a + b)),
+                    Product => o.SubPackets.Select(this.Visit).Aggregate(1UL, (a, b) => checked(a * b)),
+                    Minimum => o.SubPackets.Select(this.Visit).Min(),
+                    Maximum => o.SubPackets.Select(this.Visit).Max(),
+                    GreaterThan => this.Visit(o.SubPackets[0]) > this.Visit(o.SubPackets[1]) ? 1UL : 0,
+                    LessThan => this.Visit(o.SubPackets[0]) < this.Visit(o.SubPackets[1]) ? 1UL : 0,
+                    EqualTo => this.Visit(o.SubPackets[0]) == this.Visit(o.SubPackets[1]) ? 1UL : 0,
+                    _ => throw new InvalidOperationException($"Invalid operator type { o.Type }!"),
+                };
+        }
+    }
+}


### PR DESCRIPTION
Finally a good use of the [`ReadOnlySpan<T>` ref struct](https://docs.microsoft.com/en-us/dotnet/api/system.readonlyspan-1?view=net-6.0).

However, I found out that the generated `Equals()` record structs is not as smart as I expected...

+1 It's always a good day to use a visitor to traverse tree structures :)